### PR TITLE
Minter zetachain

### DIFF
--- a/contracts/MinterExtStakingAdmin.sol
+++ b/contracts/MinterExtStakingAdmin.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.20;
+
+/**
+ * @title StakingAdmin
+ * @notice Abstract contract for managing backup staking admin address and access control
+ * @dev Provides stakingAdmin state and modifier for pluggable use in minter contracts
+ */
+abstract contract StakingAdmin {
+
+    address public stakingAdmin; // Authorized stakingAdmin address
+
+    event UpdateStakingAdmin(address indexed newStakingAdmin);
+
+    /**
+     * @notice Modifier for stakingAdmin-only access
+     */
+    modifier onlyStakingAdmin() {
+        require(msg.sender == stakingAdmin, "NotStakingAdmin");
+        _;
+    }
+
+    /**
+     * @notice Initializes the stakingAdmin address
+     */
+    constructor() {
+        stakingAdmin = msg.sender;
+    }
+
+    /**
+     * @notice Updates the stakingAdmin address
+     * @param newStakingAdmin New stakingAdmin address
+     */
+    function updateStakingAdmin(address newStakingAdmin) public onlyStakingAdmin {
+        require(newStakingAdmin != address(0), "InvalidAddress");
+        stakingAdmin = newStakingAdmin;
+        emit UpdateStakingAdmin(newStakingAdmin);
+    }
+}

--- a/contracts/minters/stZETAMinterV203.sol
+++ b/contracts/minters/stZETAMinterV203.sol
@@ -431,24 +431,18 @@ contract stZETAMinterV203 is NativeMinterWithdrawal, StakingAdmin {
     // Undelegate tokens from a specific validator
     function undelegate(string memory validator, uint256 amount) external onlyOwner {
         require(amount > 0, "ZeroAmount");
-        (uint256 shares, ) = staking.delegation(address(this), validator);
-        require(shares >= amount, "NotEnoughTokensDelegated");
         staking.undelegate(address(this), validator, amount);
     }
 
     // Redelegate tokens from one validator to another
     function redelegate(string memory validatorSrc, string memory validatorDst, uint256 amount) external onlyOwner {
         require(amount > 0, "ZeroAmount");
-        (uint256 shares, ) = staking.delegation(address(this), validatorSrc);
-        require(shares >= amount, "NotEnoughTokensDelegated");
         staking.redelegate(address(this), validatorSrc, validatorDst, amount);
     }
 
     // Undelegate tokens from a specific validator by staking admin
     function emergencyUndelegate(string memory validator, uint256 amount) external onlyStakingAdmin {
         require(amount > 0, "ZeroAmount");
-        (uint256 shares, ) = staking.delegation(address(this), validator);
-        require(shares >= amount, "NotEnoughTokensDelegated");
         staking.undelegate(address(this), validator, amount);
     }
 

--- a/contracts/minters/stZETAMinterV203.sol
+++ b/contracts/minters/stZETAMinterV203.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "../MinterV203.sol";
+import "../MinterExtStakingAdmin.sol";
 
 /// @dev Allocation represents a single allocation for an IBC fungible token transfer.
 struct ICS20Allocation {
@@ -410,33 +411,50 @@ interface StakingI {
     );
 }
 
-contract stZETAMinterV203 is NativeMinterWithdrawal {
+contract stZETAMinterV203 is NativeMinterWithdrawal, StakingAdmin {
 
     address constant STAKING_CONTRACT = 0x0000000000000000000000000000000000000800;
     StakingI private staking = StakingI(STAKING_CONTRACT);
 
     string public BASE_URI = "https://api.accumulated.finance/v1/nft";
 
-    constructor(address _stakingToken) NativeMinterWithdrawal(_stakingToken, "unstZETA", "unstZETA", BASE_URI) {
+    constructor(address _stakingToken) NativeMinterWithdrawal(_stakingToken, "unstZETA", "unstZETA", BASE_URI) StakingAdmin() {
     }
 
     // Delegate tokens to a specific validator
     function delegate(string memory validator, uint256 amount) external onlyOwner {
-        require(amount > 0, "Amount must be greater than 0");
-        require(address(this).balance >= amount, "Insufficient contract balance");
+        require(amount > 0, "ZeroAmount");
+        require(address(this).balance >= amount, "NotEnoughTokens");
         staking.delegate(address(this), validator, amount);
     }
 
     // Undelegate tokens from a specific validator
     function undelegate(string memory validator, uint256 amount) external onlyOwner {
-        require(amount > 0, "Amount must be greater than 0");
+        require(amount > 0, "ZeroAmount");
+        (uint256 shares, ) = staking.delegation(address(this), validator);
+        require(shares >= amount, "NotEnoughTokensDelegated");
         staking.undelegate(address(this), validator, amount);
     }
 
     // Redelegate tokens from one validator to another
     function redelegate(string memory validatorSrc, string memory validatorDst, uint256 amount) external onlyOwner {
-        require(amount > 0, "Amount must be greater than 0");
+        require(amount > 0, "ZeroAmount");
+        (uint256 shares, ) = staking.delegation(address(this), validatorSrc);
+        require(shares >= amount, "NotEnoughTokensDelegated");
         staking.redelegate(address(this), validatorSrc, validatorDst, amount);
+    }
+
+    // Undelegate tokens from a specific validator by staking admin
+    function emergencyUndelegate(string memory validator, uint256 amount) external onlyStakingAdmin {
+        require(amount > 0, "ZeroAmount");
+        (uint256 shares, ) = staking.delegation(address(this), validator);
+        require(shares >= amount, "NotEnoughTokensDelegated");
+        staking.undelegate(address(this), validator, amount);
+    }
+
+    // Returns number of shares delegated to a specific validator
+    function delegation(string memory validator) public view returns (uint256 shares) {
+        (shares, ) = staking.delegation(address(this), validator);
     }
 
     // Disable withdrawals


### PR DESCRIPTION
- added abstract contract `StakingAdmin` for managing backup staking admin address and access control

stZETAMinter:
- added `emergencyUndelegate` method called by `stakingAdmin`
- added `delegation` view (proxy to cosmos evm method)
- improved error messages